### PR TITLE
improved handling of errors in API responses

### DIFF
--- a/examples/example_full_pipeline.ipynb
+++ b/examples/example_full_pipeline.ipynb
@@ -9,8 +9,30 @@
     "- We start from a target molecule in SMILES format.\n",
     "- We then use the models to predict a retrosynthetic path.\n",
     "- Once we have chosen the desired path, we start a new synthesis on the robotic hardware.\n",
-    "- We monitor the progress of the execution and finally download a pdf report from the analysis.\n",
-    "\n",
+    "- We monitor the progress of the execution and finally download a pdf report from the analysis."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup the logger"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import logging\n",
+    "logging.basicConfig(level=logging.INFO, format='%(levelname)s : %(message)s')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Instantiating the wrapper\n",
     "Setup the wrapper using a valida API key. You can get one on the IBM RXN website from [here](https://rxn.res.ibm.com/rxn/user/profile)."
    ]

--- a/examples/rxn4chemistry_tour.ipynb
+++ b/examples/rxn4chemistry_tour.ipynb
@@ -16,10 +16,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import logging\n",
     "from typing import Dict, List\n",
     "from rdkit import Chem\n",
     "from rdkit.Chem import AllChem\n",
     "from IPython.display import display\n",
+    "\n",
+    "logging.basicConfig(level=logging.INFO, format='%(levelname)s : %(message)s')\n",
     "\n",
     "def get_reaction_from_smiles(reaction_smiles: str) -> Chem.rdChemReactions.ChemicalReaction:\n",
     "    return AllChem.ReactionFromSmarts(reaction_smiles, useSmiles=True)\n",

--- a/rxn4chemistry/response_handler.py
+++ b/rxn4chemistry/response_handler.py
@@ -1,0 +1,118 @@
+import logging
+from typing import Optional, Callable, Any
+
+import requests
+
+logger = logging.getLogger(__name__)
+logger.addHandler(logging.NullHandler())
+
+
+class ResponseHandler:
+    """
+    Class to handle responses from the API in case of success or error.
+    """
+
+    def __init__(
+        self,
+        response: requests.models.Response,
+        success_status_code: int,
+        on_success: Callable[[requests.models.Response], Any],
+    ):
+        """
+        Args:
+            response: response from the API.
+            success_status_code: status expected on success.
+            on_success: function to call on success.
+        """
+        self.response = response
+        self.success_status_code = success_status_code
+        self.on_success = on_success
+
+        # it is practical to store the response dict as a member variable
+        try:
+            self._response_dict = self.response.json()
+        except ValueError:
+            self._response_dict = None
+
+        # it is practical to store the payload as a member variable
+        if self._response_dict is None:
+            self._payload = None
+        else:
+            self._payload = self._response_dict.get("payload", None)
+
+    def handle(self) -> Any:
+        """
+        Handle the response for the different cases: success, or different
+        kinds of errors.
+        """
+        successful_status = self.response.status_code == self.success_status_code
+        error_in_response_dict = self._response_dict_has_error_status()
+
+        # Success: must be the adequate status code, and there must be no
+        # error in the response body. All other cases are considered to be
+        # an error.
+        if successful_status and not error_in_response_dict:
+            return self.on_success(self.response)
+
+        self._print_error_logs()
+
+        if self._response_dict is not None:
+            return {"response": self._response_dict}
+        else:
+            return {"response": self.response.text}
+
+    def _print_error_logs(self) -> None:
+        # error-specific logs
+        if self._response_dict_has_error_status():
+            logger.error(f"Execution error.")
+            error_title = self._get_error_title()
+            if error_title is not None:
+                logger.error(f"Error title : {error_title}")
+            error_detail = self._get_error_detail()
+            if error_detail is not None:
+                logger.error(f"Error detail: {error_detail}")
+        elif self.response.status_code == 401:
+            logger.error(
+                "There is probably something wrong with your api key. Please check."
+            )
+        else:
+            logger.error(f"Unexpected error (status code: {self.response.status_code})")
+
+        # always log the full response
+        logger.error(f"Full response: {self.response.text}")
+
+    def _get_response_dict_status(self) -> Optional[str]:
+        if self._payload is None:
+            return None
+
+        try:
+            return self._payload["task_status"]
+        except KeyError:
+            pass
+
+        try:
+            return self._payload["task"]["status"]
+        except KeyError:
+            pass
+
+        return None
+
+    def _response_dict_has_error_status(self) -> bool:
+        """
+        Check whether a response dictionary from the API has an error set to ERROR
+        by looking at the common locations.
+        """
+        status_from_dict = self._get_response_dict_status()
+        if status_from_dict is None:
+            return False
+        return status_from_dict == "ERROR"
+
+    def _get_error_title(self) -> Optional[str]:
+        if self._payload is None:
+            return None
+        return self._payload.get("title", None)
+
+    def _get_error_detail(self) -> Optional[str]:
+        if self._payload is None:
+            return None
+        return self._payload.get("detail", None)


### PR DESCRIPTION
For some errors (such as invalid SMILES strings), the RXN API returns responses with status code `200`. In these cases, the response body contains some information on the error.

With this PR:
* the `on_success` callback is not called in such cases
* adequate error messages are sent to the logger

In order for the error logs to be seen, the user must set up the logging. Hence, I updated the notebooks so that the logs are shown to the user.

See an example in the image below. Before this PR, this call would have failed with a cryptic JSON decoding error.
![image](https://user-images.githubusercontent.com/6941539/162982751-d7499f1f-7fd6-4f69-b7fa-0ec374776ef6.png)
