### PR TITLE
Forward more outcomes

### DIFF
--- a/rxn4chemistry/core.py
+++ b/rxn4chemistry/core.py
@@ -332,7 +332,7 @@ class RXN4ChemistryWrapper:
         ai_model: str = "2020-08-10",
     ) -> requests.models.Response:
         """
-        Get alternative predict reaction results for a prediction_id.
+        Generate alternative predict reaction results for a prediction_id.
 
         Args:
             prediction_id (str): prediction identifier.
@@ -347,12 +347,12 @@ class RXN4ChemistryWrapper:
             ValueError: in case self.project_id is not set.
 
         Examples:
-            Get alternative results from a reaction prediction by providing the prediction
-            identifier:
+            Generate alternative results from a reaction prediction by providing the prediction
+            identifier and the prediction inputs:
 
-            >>> rxn4chemistry_wrapper.get_predict_reaction_alternative_results(
-                response['response']['payload']['id']
-                # or response['prediction_id']
+            >>> rxn4chemistry_wrapper.predict_reaction_alternative_results(
+                prediction_id=response['response']['payload']['id'],  # or response['prediction_id']
+                precursors='BrBr.c1ccc2cc3ccccc3cc2c1'
             )
             {...}
         """

--- a/rxn4chemistry/response_handler.py
+++ b/rxn4chemistry/response_handler.py
@@ -54,7 +54,8 @@ class ResponseHandler:
         if (
             successful_status
             and not error_in_response_dict
-            and self._payload is not None and self._response_dict is not None
+            and self._payload is not None
+            and self._response_dict is not None
         ):
             return self.on_success(self.response)
 

--- a/rxn4chemistry/urls.py
+++ b/rxn4chemistry/urls.py
@@ -49,6 +49,9 @@ class RXN4ChemistryRoutes:
         self.reaction_prediction_results_url = "{}/{}".format(
             self.predictions_url, "{prediction_id}"
         )
+        self.reaction_prediction_alternative_results_url = "{}/{}".format(
+            self.predictions_url, "prb"
+        )
         self.reaction_prediction_batch_url = "{}/batch".format(
             self.reaction_prediction_url, "batch"
         )


### PR DESCRIPTION
Signed-off-by: Matteo Manica <drugilsberg@gmail.com>


Here an example for the usage of the new wrapper endpoint:

```python
import time
from rxn4chemistry import RXN4ChemistryWrapper
api_key = 'YOUR_API_KEY'                                                                                                      
rxn4chemistry_wrapper = RXN4ChemistryWrapper(api_key=api_key)
rxn4chemistry_wrapper.create_project('test_wrapper')
time.sleep(5)
response = rxn4chemistry_wrapper.predict_reaction(
     precursors='BrBr.c1ccc2cc3ccccc3cc2c1'
)
time.sleep(5)
results = rxn4chemistry_wrapper.get_predict_reaction_results(
    response['prediction_id']
)
print(f"Prediction={response['prediction_id']} number of outcomes: {len(results['response']['payload']['attempts'])}")
time.sleep(5)
response_alternative = rxn4chemistry_wrapper.predict_reaction_alternative_results(
     precursors='BrBr.c1ccc2cc3ccccc3cc2c1', prediction_id=response['prediction_id']
)
time.sleep(10)
results = rxn4chemistry_wrapper.get_predict_reaction_results(
    response['prediction_id']
)
print(f"Prediction={response['prediction_id']} number of outcomes: {len(results['response']['payload']['attempts'])}")
```
