### PR TITLE
Support for forward batch predictions with multiple outcomes

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,25 @@ print(rxn4chemistry_wrapper.get_predict_reaction_batch_results(response["task_id
 
 **NOTE:** the results for batch prediction are not stored permanently in our databases, so we strongly recommend to save them since they will expire.
 
+## Multiple outcome prediction in batch
+
+It is also possible to predict multiple forward reaction prediction outcomes in batch:
+
+```python
+response = rxn4chemistry_wrapper.predict_reaction_batch_topn(
+    precursors_lists=[
+        ["BrBr", "c1ccc2cc3ccccc3cc2c1"],
+        ["BrBr", "c1ccc2cc3ccccc3cc2c1CCO"],
+    ],
+    topn=3,
+)
+# wait for the predictions to complete
+time.sleep(2)
+print(rxn4chemistry_wrapper.get_predict_reaction_batch_topn_results(response["task_id"]))
+```
+
+**NOTE:** the results for batch prediction are not stored permanently in our databases, so we strongly recommend to save them since they will expire.
+
 ## Examples
 
 To learn more see the [examples](./examples).

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ print(rxn4chemistry_wrapper.get_predict_reaction_batch_results(response["task_id
 
 **NOTE:** the results for batch prediction are not stored permanently in our databases, so we strongly recommend to save them since they will expire.
 
-## Multiple outcome prediction in batch
+## Prediction of multiple reaction outcomes (in batch)
 
 It is also possible to predict multiple forward reaction prediction outcomes in batch:
 

--- a/examples/rxn4chemistry_tour.ipynb
+++ b/examples/rxn4chemistry_tour.ipynb
@@ -188,7 +188,55 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**NOTE:** the results for batch prediction are not stored permanently in our databases, so we strongly recommend to save them since they will expire."
+    "It is also possible to predict multiple forward reaction prediction outcomes (in batch):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = rxn4chemistry_wrapper.predict_reaction_batch_topn(\n",
+    "    precursors_lists=[\n",
+    "        [\"BrBr\", \"c1ccc2cc3ccccc3cc2c1\"],\n",
+    "        [\"BrBr\", \"c1ccc2cc3ccccc3cc2c1CCO\"],\n",
+    "        [\"Cl\", \"CCC(=O)NCCC\", \"O\"],\n",
+    "    ],\n",
+    "    topn=5,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result = rxn4chemistry_wrapper.get_predict_reaction_batch_topn_results(\n",
+    "    response[\"task_id\"]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for i, reaction_predictions in enumerate(result['predictions'], 1):\n",
+    "    print(f'Outcomes for reaction no {i}:')\n",
+    "    for j, prediction in enumerate(reaction_predictions[\"results\"], 1):\n",
+    "        product_smiles = \".\".join(prediction[\"smiles\"])\n",
+    "        confidence = prediction[\"confidence\"]\n",
+    "        print(f'  Product(s) {j}: {product_smiles}, with confidence {confidence}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**NOTE:** the results for batch predictions are not stored permanently in our databases, so we strongly recommend to save them since they will expire."
    ]
   },
   {

--- a/rxn4chemistry/callbacks.py
+++ b/rxn4chemistry/callbacks.py
@@ -243,6 +243,8 @@ def predict_reaction_batch_on_success(response: requests.models.Response) -> dic
     """
     Process the successful response of requests returning predict reaction batch results.
 
+    Note: this function is also used for the batch-topn endpoint.
+
     Args:
         response (requests.models.Response): response from an API request.
 

--- a/rxn4chemistry/core.py
+++ b/rxn4chemistry/core.py
@@ -479,7 +479,7 @@ class RXN4ChemistryWrapper:
         self, precursors_lists: List[List[str]], topn: int, ai_model: str = "2020-08-10"
     ) -> requests.models.Response:
         """
-        Launch batch of reactions with multiple reactions given precursors SMILES.
+        Launch prediction of multiple outcomes for batch of reactions given precursors SMILES.
 
         Args:
             precursors_lists: lists of precursor SMILES (one list of precursors per reaction).

--- a/rxn4chemistry/core.py
+++ b/rxn4chemistry/core.py
@@ -411,7 +411,7 @@ class RXN4ChemistryWrapper:
         Launch prediction given precursors SMILES.
 
         Args:
-            precursors (List[str]): list of precursor SMILES separated with a '.'.
+            precursors_list (List[str]): list of precursor SMILES separated with a '.'.
             ai_model (str, optional): model release. Defaults to
                 '2020-08-10'.
 
@@ -468,6 +468,78 @@ class RXN4ChemistryWrapper:
         """
         response = requests.get(
             self.routes.reaction_prediction_batch_results_url.format(task_id=task_id),
+            headers=self.headers,
+            cookies={},
+        )
+        return response
+
+    @response_handling(success_status_code=200, on_success=task_id_on_success)
+    @ibm_rxn_api_limits
+    def predict_reaction_batch_topn(
+        self, precursors_lists: List[List[str]], topn: int, ai_model: str = "2020-08-10"
+    ) -> requests.models.Response:
+        """
+        Launch batch of reactions with multiple reactions given precursors SMILES.
+
+        Args:
+            precursors_lists: lists of precursor SMILES (one list of precursors per reaction).
+            topn: number of predictions to make per reaction.
+            ai_model: model release.
+
+        Returns:
+            dict: dictionary containing the response.
+
+        Raises:
+            ValueError: in case self.project_id is not set.
+
+        Examples:
+            Predict a reaction batch (with multiple predictions) by providing the
+            lists of precursors and get task identifier
+            and status:
+
+            >>> response = rxn4chemistry_wrapper.predict_reaction_batch_topn(
+            ...     ['BrBr', 'c1ccc2cc3ccccc3cc2c1'], ['Cl', 'c1ccc2cc3ccccc3cc2c1'],
+            ...     topn=4
+            ... )
+        """
+        data = {"precursors_lists": precursors_lists, "topn": topn, "aiModel": ai_model}
+        response = requests.post(
+            self.routes.reaction_prediction_batch_topn_url,
+            headers=self.headers,
+            data=json.dumps(data),
+            cookies={},
+        )
+        return response
+
+    @response_handling(
+        success_status_code=200, on_success=predict_reaction_batch_on_success
+    )
+    @ibm_rxn_api_limits
+    def get_predict_reaction_batch_topn_results(
+        self, task_id: str
+    ) -> requests.models.Response:
+        """
+        Get the results for a batch with multiple predictions for a task_id.
+
+        Args:
+            task_id: task identifier.
+
+        Returns:
+            dict: dictionary containing the prediction results.
+
+        Examples:
+            Get results from a reaction prediction by providing the prediction
+            identifier:
+
+            >>> rxn4chemistry_wrapper.get_predict_reaction_batch_topn_results(
+            ...     response["task_id"]
+            ... )
+            ... {...}
+        """
+        response = requests.get(
+            self.routes.reaction_prediction_batch_topn_results_url.format(
+                task_id=task_id
+            ),
             headers=self.headers,
             cookies={},
         )

--- a/rxn4chemistry/urls.py
+++ b/rxn4chemistry/urls.py
@@ -52,11 +52,17 @@ class RXN4ChemistryRoutes:
         self.reaction_prediction_alternative_results_url = "{}/{}".format(
             self.predictions_url, "prb"
         )
-        self.reaction_prediction_batch_url = "{}/batch".format(
+        self.reaction_prediction_batch_url = "{}/{}".format(
             self.reaction_prediction_url, "batch"
         )
         self.reaction_prediction_batch_results_url = "{}/{}".format(
             self.reaction_prediction_batch_url, "{task_id}"
+        )
+        self.reaction_prediction_batch_topn_url = "{}/{}".format(
+            self.reaction_prediction_url, "batch_topn"
+        )
+        self.reaction_prediction_batch_topn_results_url = "{}/{}".format(
+            self.reaction_prediction_batch_topn_url, "{task_id}"
         )
         self.retrosynthesis_prediction_url = "{}/{}".format(
             self.retrosynthesis_url, "rs"


### PR DESCRIPTION
Test with the following (or look at changes in the `README` and notebook):

```python
response = rxn4chemistry_wrapper.predict_reaction_batch_topn(
    precursors_lists=[
        ["BrBr", "c1ccc2cc3ccccc3cc2c1"],
        ["BrBr", "c1ccc2cc3ccccc3cc2c1CCO"],
    ],
    topn=3,
)
print(response)

time.sleep(5)

result = rxn4chemistry_wrapper.get_predict_reaction_batch_topn_results(
    response["task_id"]
)

pprint(result)
```