### PR TITLE
redirect error

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,26 @@ rxn4chemistry_wrapper = RXN4ChemistryWrapper(api_key=api_key, base_url='https://
 # rxn4chemistry_wrapper.set_base_url('https://some.other.rxn.server')
 ```
 
+
+### Enable logging
+
+Logging by the library is disabled by default as it may interfere with programmatic uses.
+In the very top of the notebook you can seeing a line that enabled all logging in the notebook.
+```python
+import logging
+logging.basicConfig(level=logging.INFO, format='%(levelname)s : %(message)s')
+```
+This may also enable logging from other libraries. If you wish to selectively enable the logs from `rxn4chemistry`, consider something like this:
+```python
+import logging
+logger = logging.getLogger("rxn4chemistry")
+handler = logging.StreamHandler()
+handler.setFormatter(logging.Formatter('%(levelname)s : %(message)s'))
+logger.addHandler(handler)
+logger.setLevel(logging.DEBUG)
+```
+
+
 ### Create a project
 
 Get your API key from [here](https://rxn.res.ibm.com/rxn/user/profile) and build the wrapper:
@@ -183,6 +203,25 @@ print(rxn4chemistry_wrapper.get_predict_reaction_batch_topn_results(response["ta
 ```
 
 **NOTE:** the results for batch prediction are not stored permanently in our databases, so we strongly recommend to save them since they will expire.
+
+## Enable logging
+
+Logging by the library is disabled by default as it may interfere with programmatic uses.
+
+In the very top of the notebook you can seeing a line that enabled all logging in the notebook.
+```python
+import logging
+logging.basicConfig(level=logging.INFO, format='%(levelname)s : %(message)s')
+```
+This may also enable logging from other libraries. If you wish to selectively enable the logs from `rxn4chemistry`, consider something like this:
+```python
+import logging
+logger = logging.getLogger("rxn4chemistry")
+handler = logging.StreamHandler()
+handler.setFormatter(logging.Formatter('%(levelname)s : %(message)s'))
+logger.addHandler(handler)
+logger.setLevel(logging.DEBUG)
+```
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ print(rxn4chemistry_wrapper.get_predict_reaction_batch_topn_results(response["ta
 
 Logging by the library is disabled by default as it may interfere with programmatic uses.
 
-In the very top of the notebook you can seeing a line that enabled all logging in the notebook.
+In the very top of the `rxn4chemistry_tour.ipynb` example notebook you can seeing a line that enables all logging in the notebook.
 ```python
 import logging
 logging.basicConfig(level=logging.INFO, format='%(levelname)s : %(message)s')

--- a/README.md
+++ b/README.md
@@ -44,26 +44,6 @@ rxn4chemistry_wrapper = RXN4ChemistryWrapper(api_key=api_key, base_url='https://
 # rxn4chemistry_wrapper.set_base_url('https://some.other.rxn.server')
 ```
 
-
-### Enable logging
-
-Logging by the library is disabled by default as it may interfere with programmatic uses.
-In the very top of the notebook you can seeing a line that enabled all logging in the notebook.
-```python
-import logging
-logging.basicConfig(level=logging.INFO, format='%(levelname)s : %(message)s')
-```
-This may also enable logging from other libraries. If you wish to selectively enable the logs from `rxn4chemistry`, consider something like this:
-```python
-import logging
-logger = logging.getLogger("rxn4chemistry")
-handler = logging.StreamHandler()
-handler.setFormatter(logging.Formatter('%(levelname)s : %(message)s'))
-logger.addHandler(handler)
-logger.setLevel(logging.DEBUG)
-```
-
-
 ### Create a project
 
 Get your API key from [here](https://rxn.res.ibm.com/rxn/user/profile) and build the wrapper:

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ print(rxn4chemistry_wrapper.get_predict_reaction_batch_topn_results(response["ta
 
 Logging by the library is disabled by default as it may interfere with programmatic uses.
 
-In the very top of the `rxn4chemistry_tour.ipynb` example notebook you can seeing a line that enables all logging in the notebook.
+In the very top of the `rxn4chemistry_tour.ipynb` example notebook you can see a line that enables all logging in the notebook.
 ```python
 import logging
 logging.basicConfig(level=logging.INFO, format='%(levelname)s : %(message)s')

--- a/rxn4chemistry/callbacks.py
+++ b/rxn4chemistry/callbacks.py
@@ -1,10 +1,13 @@
 """Callbacks for IBM RXN for Chemistry API."""
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import logging
+
 import requests
 from bs4 import BeautifulSoup
 
-from .logging import logger
+logger = logging.getLogger(__name__)
+logger.addHandler(logging.NullHandler())
 
 BORDER_COLOR_COMMERCIAL = set(["#28a30d", "#0f62fe", "#002d9c"])
 BORDER_COLOR_UNAVAILABLE = set(["#ce4e04"])

--- a/rxn4chemistry/callbacks.py
+++ b/rxn4chemistry/callbacks.py
@@ -1,11 +1,10 @@
 """Callbacks for IBM RXN for Chemistry API."""
 from __future__ import absolute_import, division, print_function, unicode_literals
-import logging
+
 import requests
 from bs4 import BeautifulSoup
 
-logger = logging.getLogger(__name__)
-logger.addHandler(logging.NullHandler())
+from .logging import logger
 
 BORDER_COLOR_COMMERCIAL = set(["#28a30d", "#0f62fe", "#002d9c"])
 BORDER_COLOR_UNAVAILABLE = set(["#ce4e04"])

--- a/rxn4chemistry/core.py
+++ b/rxn4chemistry/core.py
@@ -1,31 +1,30 @@
 """Core IBM RXN for Chemistry API module."""
 from __future__ import absolute_import, division, print_function, unicode_literals
-import copy
-import requests
-import logging
-import json
-from typing import Optional, List, Dict, Tuple, Any
 
-from .urls import RXN4ChemistryRoutes
-from .decorators import ibm_rxn_api_limits, response_handling
+import copy
+import json
+from typing import Any, Dict, List, Optional, Tuple
+
+import requests
+
 from .callbacks import (
-    prediction_id_on_success,
-    task_id_on_success,
+    automatic_retrosynthesis_results_on_success,
     default_on_success,
     model_listing_on_success,
-    automatic_retrosynthesis_results_on_success,
-    retrosynthesis_sequence_pdf,
     paragraph_to_actions_on_success,
+    predict_reaction_batch_on_success,
+    prediction_id_on_success,
+    retrosynthesis_sequence_pdf,
+    synthesis_analysis_report_pdf,
+    synthesis_execution_id_on_success,
+    synthesis_execution_status_on_success,
     synthesis_id_on_success,
     synthesis_on_success,
-    synthesis_execution_status_on_success,
-    synthesis_execution_id_on_success,
-    synthesis_analysis_report_pdf,
-    predict_reaction_batch_on_success,
+    task_id_on_success,
 )
-
-logger = logging.getLogger(__name__)
-logger.addHandler(logging.NullHandler())
+from .decorators import ibm_rxn_api_limits, response_handling
+from .logging import logger
+from .urls import RXN4ChemistryRoutes
 
 
 def post_order_tree_traversal(tree: Dict) -> List[Dict]:

--- a/rxn4chemistry/core.py
+++ b/rxn4chemistry/core.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import copy
 import json
+import logging
 from typing import Any, Dict, List, Optional, Tuple
 
 import requests
@@ -23,8 +24,10 @@ from .callbacks import (
     task_id_on_success,
 )
 from .decorators import ibm_rxn_api_limits, response_handling
-from .logging import logger
 from .urls import RXN4ChemistryRoutes
+
+logger = logging.getLogger(__name__)
+logger.addHandler(logging.NullHandler())
 
 
 def post_order_tree_traversal(tree: Dict) -> List[Dict]:

--- a/rxn4chemistry/decorators.py
+++ b/rxn4chemistry/decorators.py
@@ -1,6 +1,7 @@
 """Decorators for IBM RXN for Chemistry API."""
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import logging
 import threading
 import time
 from functools import partial, wraps
@@ -9,8 +10,10 @@ from typing import Any, Callable, Optional
 import requests
 
 from .callbacks import default_on_success
-from .logging import logger
 from .response_handler import ResponseHandler
+
+logger = logging.getLogger(__name__)
+logger.addHandler(logging.NullHandler())
 
 MAXIMUM_REQUESTS_PER_MINUTE = 1e5
 MININUM_TIMEOUT_BETWEEN_REQUESTS = 1e-5  # expressed in seconds

--- a/rxn4chemistry/decorators.py
+++ b/rxn4chemistry/decorators.py
@@ -1,18 +1,16 @@
 """Decorators for IBM RXN for Chemistry API."""
 from __future__ import absolute_import, division, print_function, unicode_literals
-import time
-import logging
+
 import threading
-from typing import Optional, Callable, Any
-from functools import wraps, partial
+import time
+from functools import partial, wraps
+from typing import Any, Callable, Optional
 
 import requests
 
 from .callbacks import default_on_success
+from .logging import logger
 from .response_handler import ResponseHandler
-
-logger = logging.getLogger(__name__)
-logger.addHandler(logging.NullHandler())
 
 MAXIMUM_REQUESTS_PER_MINUTE = 1e5
 MININUM_TIMEOUT_BETWEEN_REQUESTS = 1e-5  # expressed in seconds

--- a/rxn4chemistry/logging.py
+++ b/rxn4chemistry/logging.py
@@ -1,0 +1,4 @@
+import logging
+
+logger = logging.getLogger("rxn4chemistry")
+logger.addHandler(logging.NullHandler())

--- a/rxn4chemistry/logging.py
+++ b/rxn4chemistry/logging.py
@@ -1,4 +1,0 @@
-import logging
-
-logger = logging.getLogger("rxn4chemistry")
-logger.addHandler(logging.NullHandler())

--- a/rxn4chemistry/response_handler.py
+++ b/rxn4chemistry/response_handler.py
@@ -1,9 +1,9 @@
 import logging
-from typing import Optional, Callable, Any
+from typing import Any, Callable, Optional
 
 import requests
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("rxn4chemistry")
 logger.addHandler(logging.NullHandler())
 
 
@@ -67,13 +67,34 @@ class ResponseHandler:
             return {"response": self.response.text}
 
     def _print_error_logs(self) -> None:
+        """Note that logging has to be enabled, by default there is no output."""
         # error-specific logs
-        if self._payload is None or self._response_dict is None:
+        if self.response.status_code == 401 and len(self.response.history) > 0:
+            urls = {
+                "original": self.response.history[0].url,
+                "redirected": self.response.url,
+            }
+            longest_k = len(max(urls.keys(), key=len))
+            longest_v = len(max(urls.values(), key=len))
+            comparison = "\n".join(
+                [f"{k : >{longest_k}} url: {v : >{longest_v}}" for k, v in urls.items()]
+            )
+            logger.error(
+                "The api key was removed due to a redirect of the request.\n"
+                "You will have to set the base_url to the redirected url to "
+                "to prevent this failure. See `RXN4ChemistryWrapper()` or "
+                "RXN4ChemistryWrapper.set_base_url().\n"
+                f"Check this comparison to infer the redirected base_url:\n{comparison}"
+            )
+            # this is done by the request package without warning
+            # see https://github.com/psf/requests/pull/5375
+            # the only workaround would be via a .netrc file
+        elif self._payload is None or self._response_dict is None:
             logger.error(
                 "The service might be overloaded at the moment. Please try again."
             )
         elif self._response_dict_has_error_status():
-            logger.error(f"Execution error.")
+            logger.error("Execution error.")
             error_title = self._get_error_title()
             if error_title is not None:
                 logger.error(f"Error title : {error_title}")

--- a/rxn4chemistry/response_handler.py
+++ b/rxn4chemistry/response_handler.py
@@ -70,6 +70,14 @@ class ResponseHandler:
         """Note that logging has to be enabled, by default there is no output."""
         # error-specific logs
         if self.response.status_code == 401 and len(self.response.history) > 0:
+            # In case the base_url responded with a redirect, the `requests` package
+            # stores these calls in the history attribute and follows up to the
+            # new url. But it strips Authorization headers (i.e. the api key) from
+            # the redirected request for security reasons without warning
+            # see https://github.com/psf/requests/pull/5375
+            # the only workaround would be via a .netrc file
+
+            # in this case, the user needs to update the base_url, which we know now.
             urls = {
                 "original": self.response.history[0].url,
                 "redirected": self.response.url,
@@ -86,9 +94,6 @@ class ResponseHandler:
                 "RXN4ChemistryWrapper.set_base_url().\n"
                 f"Check this comparison to infer the redirected base_url:\n{comparison}"
             )
-            # this is done by the request package without warning
-            # see https://github.com/psf/requests/pull/5375
-            # the only workaround would be via a .netrc file
         elif self._payload is None or self._response_dict is None:
             logger.error(
                 "The service might be overloaded at the moment. Please try again."

--- a/rxn4chemistry/response_handler.py
+++ b/rxn4chemistry/response_handler.py
@@ -1,10 +1,8 @@
-import logging
 from typing import Any, Callable, Optional
 
 import requests
 
-logger = logging.getLogger(__name__)
-logger.addHandler(logging.NullHandler())
+from .logging import logger
 
 
 class ResponseHandler:

--- a/rxn4chemistry/response_handler.py
+++ b/rxn4chemistry/response_handler.py
@@ -1,8 +1,10 @@
+import logging
 from typing import Any, Callable, Optional
 
 import requests
 
-from .logging import logger
+logger = logging.getLogger(__name__)
+logger.addHandler(logging.NullHandler())
 
 
 class ResponseHandler:

--- a/rxn4chemistry/response_handler.py
+++ b/rxn4chemistry/response_handler.py
@@ -3,7 +3,7 @@ from typing import Any, Callable, Optional
 
 import requests
 
-logger = logging.getLogger("rxn4chemistry")
+logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
 


### PR DESCRIPTION
Main point is to catch and inform about any redirections which are expected to fail for security reasons (not sending auth somewhere else than you told it to). Instead we give the hint to change the `base_url`

common logger instance for ease of enabling selective logging of the full library. I don't think we need the flexibility to change the logging per module.
